### PR TITLE
Update runtime and application

### DIFF
--- a/cmake-fix.patch
+++ b/cmake-fix.patch
@@ -1,0 +1,51 @@
+From 523e5e55dc52c799bb5e7b4d48e333da0e673543 Mon Sep 17 00:00:00 2001
+From: Eric Wasylishen <ewasylishen@gmail.com>
+Date: Sun, 4 Apr 2021 20:49:26 -0600
+Subject: [PATCH] 3739: work around link errors with cmake 3.20.0
+
+AUTOMOC on the "common" target was not propagating to the tools that
+depend on it?
+
+Fixes #3739
+---
+ common/benchmark/CMakeLists.txt | 1 +
+ common/test/CMakeLists.txt      | 1 +
+ dump-shortcuts/CMakeLists.txt   | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/common/benchmark/CMakeLists.txt b/common/benchmark/CMakeLists.txt
+index d4dfb55225..34d6b0d802 100644
+--- a/common/benchmark/CMakeLists.txt
++++ b/common/benchmark/CMakeLists.txt
+@@ -13,6 +13,7 @@ set_property(SOURCE "${COMMON_BENCHMARK_SOURCE_DIR}/Main.cpp" PROPERTY SKIP_UNIT
+ add_executable(common-benchmark ${COMMON_BENCHMARK_SOURCE})
+ target_include_directories(common-benchmark PRIVATE ${COMMON_BENCHMARK_SOURCE_DIR})
+ target_link_libraries(common-benchmark PRIVATE common Catch2::Catch2)
++set_target_properties(common-benchmark PROPERTIES AUTOMOC TRUE)
+ 
+ set_compiler_config(common-benchmark)
+ 
+diff --git a/common/test/CMakeLists.txt b/common/test/CMakeLists.txt
+index 74b3e863fa..79c30a797b 100644
+--- a/common/test/CMakeLists.txt
++++ b/common/test/CMakeLists.txt
+@@ -117,6 +117,7 @@ set_property(SOURCE "${COMMON_TEST_SOURCE_DIR}/RunAllTests.cpp" PROPERTY SKIP_UN
+ add_executable(common-test ${COMMON_TEST_SOURCE})
+ target_include_directories(common-test PRIVATE ${COMMON_TEST_SOURCE_DIR})
+ target_link_libraries(common-test PRIVATE common Catch2::Catch2)
++set_target_properties(common-test PROPERTIES AUTOMOC TRUE)
+ 
+ set_compiler_config(common-test)
+ 
+diff --git a/dump-shortcuts/CMakeLists.txt b/dump-shortcuts/CMakeLists.txt
+index e4eb6be57e..27626bac0f 100644
+--- a/dump-shortcuts/CMakeLists.txt
++++ b/dump-shortcuts/CMakeLists.txt
+@@ -9,6 +9,7 @@ set(DUMP_SHORTCUTS_SOURCE ${DUMP_SHORTCUTS_SOURCE} ${INDEX_OUTPUT_PATH} ${DOC_MA
+ add_executable(dump-shortcuts ${DUMP_SHORTCUTS_SOURCE})
+ target_include_directories(dump-shortcuts PRIVATE ${DUMP_SHORTCUTS_SOURCE_DIR})
+ target_link_libraries(dump-shortcuts PRIVATE common)
++set_target_properties(dump-shortcuts PROPERTIES AUTOMOC TRUE)
+ 
+ set_compiler_config(dump-shortcuts)
+ 

--- a/com.kristianduske.TrenchBroom.appdata.xml
+++ b/com.kristianduske.TrenchBroom.appdata.xml
@@ -21,6 +21,7 @@
   <content_rating type="oars-1.1"/>
   <update_contact>kristian.duske@gmail.com</update_contact>
   <releases>
+    <release version="2021.1" date="2021-02-14"></release>
     <release version="2020.2" date="2020-09-29"></release>
   </releases>
 </component>

--- a/com.kristianduske.TrenchBroom.json
+++ b/com.kristianduske.TrenchBroom.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.kristianduske.TrenchBroom",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.12",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "command": "trenchbroom.sh",
     "rename-icon": "trenchbroom",
@@ -38,7 +38,7 @@
         }
     },
     "modules": [
-        "shared-modules/glu/glu-9.0.0.json",
+        "shared-modules/glu/glu-9.json",
         {
             "name": "freeimage",
             "buildsystem": "autotools",
@@ -75,19 +75,22 @@
         },
         {
             "name": "trenchbroom",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_CXX_FLAGS=-Werror",
                 "-DOpenGL_GL_PREFERENCE=GLVND"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/kduske/TrenchBroom.git",
-                    "commit": "adf452f7af039e1bd8c7a5562b56eaef70bf6a7c",
-                    "tag": "v2020.2"
+                    "commit": "532e1b4d505d5aaf710ba09192d9fbaeb963010a",
+                    "tag": "v2021.1"
+                },
+                {
+                    "type": "patch",
+                    "path": "cmake-fix.patch"
                 }
             ]
         },
@@ -119,27 +122,27 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2020.2/app/resources/linux/trenchbroom.desktop",
+                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2021.1/app/resources/linux/trenchbroom.desktop",
                     "sha256": "d9f533982b9d3d6be4b33e1a3248c7223522654da4f17c6190a408cb2e6dd2b6"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2020.2/app/resources/linux/icons/icon_32.png",
+                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2021.1/app/resources/linux/icons/icon_32.png",
                     "sha256": "ed106980868cbf33281d7907a89d856c50b167031b39bd2e0a317f30ea693a0f"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2020.2/app/resources/linux/icons/icon_64.png",
+                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2021.1/app/resources/linux/icons/icon_64.png",
                     "sha256": "c8d750883cbc837647ad5ad18177ea3e9f2725e723d02fc8e867c91aefd17404"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2020.2/app/resources/linux/icons/icon_128.png",
+                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2021.1/app/resources/linux/icons/icon_128.png",
                     "sha256": "24684fa6b2ac85afe7e9d75017a839a2c0df5d720267c910de43a3cca08d2c76"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2020.2/app/resources/linux/icons/icon_256.png",
+                    "url": "https://raw.githubusercontent.com/kduske/TrenchBroom/v2021.1/app/resources/linux/icons/icon_256.png",
                     "sha256": "9edb0d713fde4c7417fa4b3f7037974a1dedb9e3099e1202a8b744ed6f30b314"
                 }
             ]


### PR DESCRIPTION
Changing the runtime because 5.12 is EOL
Updating application to newer release with the appdata
Adding upstream cmake-fix.patch for cmake 3.20.x
Removing -Werror because there's only warning which could be ignored

The only warning present which has no fix upstream : 
```
../common/src/Model/Brush.cpp:264:37: warning: ‘<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  264 |                         return kdl::void_success;
      |                                     ^~~~~~~~~~~~
```

Runtime output:
```
Gtk-Message: 16:15:51.174: Failed to load module "canberra-gtk-module"
Gtk-Message: 16:15:51.174: Failed to load module "canberra-gtk-module"
Qt: Session management error: Could not open network socket
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
Renderer info: Radeon RX 580 Series (POLARIS10, DRM 3.40.0, 5.12.9-300.fc34.x86_64, LLVM 11.1.0) version 4.6 (Compatibility Profile) Mesa 21.1.1 (git-abac12bc75) from AMD
Depth buffer bits: 24
Multisampling enabled
Adding file system path /app/share/TrenchBroom/defaults/assets
Creating new document
Loaded entity definition file dday.fgd
Loading palette file pics/colormap.pcx
Could not load palette file 'pics/colormap.pcx': File not found: 'pics/colormap.pcx'
Renderer info: Radeon RX 580 Series (POLARIS10, DRM 3.40.0, 5.12.9-300.fc34.x86_64, LLVM 11.1.0) version 4.6 (Compatibility Profile) Mesa 21.1.1 (git-abac12bc75) from AMD
Depth buffer bits: 24
Multisampling enabled
Adding file system path /app/share/TrenchBroom/defaults/assets
Creating new document
Unquoted float default value 1.0 (line 223, column 40)
Unquoted float default value 2.0 (line 334, column 56)
Unquoted float default value 0.5 (line 335, column 108)
Unquoted float default value 4.0 (line 336, column 72)
Unquoted float default value 0.10 (line 337, column 69)
Unquoted float default value 0.20 (line 340, column 92)
Unquoted float default value 6.0 (line 358, column 53)
Unquoted float default value 2.0 (line 359, column 62)
Unquoted float default value 0.0 (line 361, column 64)
Unquoted float default value 1.0 (line 362, column 69)
Unquoted float default value 0 (line 396, column 62)
Unquoted float default value 4.0 (line 451, column 75)
Unquoted float default value 12.0 (line 452, column 76)
Unquoted float default value 1.0 (line 627, column 96)
Unquoted float default value 1.0 (line 810, column 152)
Unquoted float default value 1.0 (line 813, column 81)
Unquoted float default value 1.0 (line 815, column 60)
Unquoted float default value 1.0 (line 816, column 74)
Unquoted float default value 2.0 (line 943, column 77)
Unquoted float default value 0.0 (line 944, column 125)
Unquoted float default value 0.2 (line 1002, column 77)
Unquoted float default value 0.2 (line 1101, column 77)
Unquoted float default value 0.10 (line 1312, column 78)
Unquoted float default value 1.0 (line 1342, column 48)
Unquoted float default value 1.0 (line 1344, column 31)
Unquoted float default value 0.20 (line 3, column 59)
Unquoted float default value 1.0 (line 27, column 48)
Loaded entity definition file Episode 1.fgd
```
Not sure if anything here is bad.