### PR TITLE
Update to v2025.4

### DIFF
--- a/com.kristianduske.TrenchBroom.appdata.xml
+++ b/com.kristianduske.TrenchBroom.appdata.xml
@@ -35,6 +35,22 @@
   <content_rating type="oars-1.1"/>
   <update_contact>kristian.duske@gmail.com</update_contact>
   <releases>
+    <release version="2025.4" date="2026-01-02">
+      <url type="details">https://github.com/TrenchBroom/TrenchBroom/releases/tag/v2025.4</url>
+      <description>
+        <ul>
+          <li>Fix enabled state of vertex snapping menu entries</li>
+          <li>Fix disappearing entity links when using included FGD files</li>
+          <li>Fix entity definition shortcuts not working after creating or loading a map</li>
+          <li>Various performance improvements</li>
+          <li>Enable rotating and scaling vertices</li>
+          <li>Add support for target_destination and target_source property types</li>
+          <li>Add "Rename Selected Groups" to Groups menu</li>
+          <li>Implementation for FGD colour types</li>
+        </ul>
+        <p>For the rest of the release notes, check the link below</p>
+      </description>
+    </release>
     <release version="2025.3" date="2025-05-25">
       <url type="details">https://github.com/TrenchBroom/TrenchBroom/releases/tag/v2025.3</url>
       <description>

--- a/com.kristianduske.TrenchBroom.json
+++ b/com.kristianduske.TrenchBroom.json
@@ -64,7 +64,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/catchorg/Catch2.git",
-                    "tag": "v2.13.8"
+                    "tag": "v3.10.0"
                 }
             ]
         },
@@ -155,8 +155,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/TrenchBroom/TrenchBroom.git",
-                    "commit": "4a58e6b6b287137de7fe6d736a8c5e57f1b1209d",
-                    "tag": "v2025.3"
+                    "commit": "c3aa9586ac93c55deca4801044f3a32258bc2c1e",
+                    "tag": "v2025.4"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
https://github.com/TrenchBroom/TrenchBroom/releases/tag/v2025.4

EDIT: first test build failed because Catch2 was updated.